### PR TITLE
fix n+1 query performance issue

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: n+1 query issue

**Changes**

Querying all scores includes users in one statement

**Before**

Each score individually queried its associated user

Console logs before the fix:
<img width="1081" alt="Screenshot 2024-10-10 at 10 32 48" src="https://github.com/user-attachments/assets/296e7b3c-c3e8-4bed-9f94-fe1af6678a1e">


**After**

All required users are included in the original query

Console logs after the fix:
<img width="682" alt="Screenshot 2024-10-10 at 10 28 30" src="https://github.com/user-attachments/assets/1daf1d48-7c1f-478d-9592-775f7d9fd69e">
